### PR TITLE
add udp reporter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,12 @@ const defaults = {
         method: 'POST',
         url: 'http://localhost:5000/report',
         options: {}
+      },
+      {
+        id: './reporters/udp_reporter',
+        socketType: 'udp4',
+        port: 5001,
+        host: 'localhost'
       }
     ]
   },

--- a/lib/reporters/udp_reporter.js
+++ b/lib/reporters/udp_reporter.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const Dgram = require('dgram');
+const Merge = require('lodash.merge');
+const defaults = {
+  socketType: 'udp4'
+};
+
+
+function UdpReporter (options) {
+  this._options = Merge({}, defaults, options);
+}
+
+module.exports = UdpReporter;
+
+
+UdpReporter.prototype.report = function report (message, callback) {
+  const settings = this._options;
+  const client = Dgram.createSocket(settings.socketType);
+
+  client.send(message,
+              0,
+              message.length,
+              settings.port,
+              settings.host,
+              function sendCb (err) {
+    client.close(function closeCb () {
+      callback(err);
+    });
+  });
+};


### PR DESCRIPTION
Next steps will be to add  `start()` and `stop()` functions to the reporters. Then, for example in the UDP reporter, a client can be created on `start()` and shutdown on `stop()`, instead of creating the socket each time.

Closes #28 
