### PR TITLE
Support messages from IPC 

### DIFF
--- a/lib/clients/index.js
+++ b/lib/clients/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.WebSocket = require('./ws');
+exports.Ipc = require('./ipc');

--- a/lib/clients/ipc.js
+++ b/lib/clients/ipc.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const Net = require('net');
+const Os = require('os');
+const Insync = require('insync');
+const Split = require('split2');
+
+
+module.exports = Ipc;
+
+
+function Ipc () {
+  this.reporters = [];
+  this._client = process.env.NODE_CHANNEL_FD ? new Net.Socket({
+    fd: process.env.NODE_CHANNEL_FD,
+    readable: false,
+    writable: true
+  }) : noop;
+
+  process.on('disconnected', () => {
+    process.exit(0);
+  });
+}
+
+Ipc.prototype.write = function write (data, callback) {
+  if (typeof callback !== 'function') {
+    callback = noop;
+  }
+
+  if (this._client === null || !this._client.write) {
+    return callback();
+  }
+
+  const strData = (typeof data === 'string') ? data : JSON.stringify(data);
+  this._client.write(strData + '\n', callback);
+};
+
+Ipc.prototype.connect = function connect (commands, handler, callback) {
+  const info = {
+    pid: process.pid,
+    argv: process.argv,
+    version: process.version,
+    hostname: Os.hostname()
+  };
+
+  process.on('message', function (message) {
+    let data = message;
+    if (typeof message === 'string') {
+      try {
+        data = JSON.parse(message);
+      }
+      catch (err) {
+        console.error(err);
+        return;
+      }
+    }
+
+    handler(data)
+  });
+
+  // Register with the parent process
+  this.write({ path: 'register', payload: { commands, info } }, callback);
+};
+
+
+Ipc.prototype.respond = function respond (message, callback) {
+  this.write({ path: 'respond', payload: message }, callback);
+};
+
+
+Ipc.prototype.report = function report (message, callback) {
+  if (typeof message !== 'string') {
+    message = JSON.stringify(message);
+  }
+
+  if (typeof callback !== 'function') {
+    callback = noop;
+  }
+
+  Insync.each(this.reporters, function eachIterator (reporter, next) {
+    reporter.report(message, next);
+  }, callback);
+};
+
+
+function noop () {}

--- a/lib/clients/ipc.js
+++ b/lib/clients/ipc.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Net = require('net');
 const Os = require('os');
 const Insync = require('insync');
 
@@ -10,11 +9,7 @@ module.exports = Ipc;
 
 function Ipc () {
   this.reporters = [];
-  this._client = process.env.NODE_CHANNEL_FD ? new Net.Socket({
-    fd: process.env.NODE_CHANNEL_FD,
-    readable: false,
-    writable: true
-  }) : noop;
+  this._client = typeof process.send === 'function' ? noop : null;
 
   process.on('disconnected', () => {
     process.exit(0);
@@ -26,12 +21,11 @@ Ipc.prototype.write = function write (data, callback) {
     callback = noop;
   }
 
-  if (this._client === null || !this._client.write) {
+  if (typeof process.send !== 'function') {
     return callback();
   }
 
-  const strData = (typeof data === 'string') ? data : JSON.stringify(data);
-  this._client.write(strData + '\n', callback);
+  process.send(data, callback);
 };
 
 Ipc.prototype.connect = function connect (commands, handler, callback) {
@@ -42,7 +36,7 @@ Ipc.prototype.connect = function connect (commands, handler, callback) {
     hostname: Os.hostname()
   };
 
-  process.on('message', function (message) {
+  process.on('message', (message) => {
     let data = message;
     if (typeof message === 'string') {
       try {
@@ -68,15 +62,11 @@ Ipc.prototype.respond = function respond (message, callback) {
 
 
 Ipc.prototype.report = function report (message, callback) {
-  if (typeof message !== 'string') {
-    message = JSON.stringify(message);
-  }
-
   if (typeof callback !== 'function') {
     callback = noop;
   }
 
-  Insync.each(this.reporters, function eachIterator (reporter, next) {
+  Insync.each(this.reporters, (reporter, next) => {
     reporter.report(message, next);
   }, callback);
 };

--- a/lib/clients/ipc.js
+++ b/lib/clients/ipc.js
@@ -3,7 +3,6 @@
 const Net = require('net');
 const Os = require('os');
 const Insync = require('insync');
-const Split = require('split2');
 
 
 module.exports = Ipc;

--- a/lib/clients/ws.js
+++ b/lib/clients/ws.js
@@ -19,7 +19,7 @@ Client.prototype.connect = function connect (commands, handler, callback) {
   const self = this;
   const client = self._client;
 
-  if (this.client === null) {
+  if (client === null) {
     throw new Error('client not connected');
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const Os = require('os');
 const Path = require('path');
 const Fse = require('fs-extra');
 const Merge = require('lodash.merge');
-const Client = require('./client');
+const Clients = require('./clients');
 const Manager = require('./manager');
 
 const defaults = {
@@ -20,7 +20,7 @@ const defaults = {
 
 getConfig(defaults, function getConfigCb (err, config) {  // eslint-disable-line handle-callback-err
   const settings = Merge({}, defaults, config);
-  const client = new Client(settings.client);
+  const client = settings.client.host ? new Clients.WebSocket(settings.client) : new Clients.Ipc();
   const manager = new Manager({ client });
 
   Fse.ensureDirSync(settings.data.path);
@@ -48,7 +48,8 @@ getConfig(defaults, function getConfigCb (err, config) {  // eslint-disable-line
 
 function getConfig (defaults, callback) {
   try {
-    const ConfigFn = require(Path.join(process.cwd(), '.toolbagrc.js'));
+    const configPath = process.env.TOOLBAG_PATH || Path.join(process.cwd(), '.toolbagrc.js');
+    const ConfigFn = require(configPath);
 
     ConfigFn(defaults, callback);
   } catch (err) {

--- a/lib/plugins/process_reporter.js
+++ b/lib/plugins/process_reporter.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const Merge = require('lodash.merge');
+
+
+module.exports = { register };
+
+
+function register (manager, options, callback) {
+  const reporter = new ProcessReporter(options);
+
+  manager.client.reporters.push(reporter);
+  callback();
+}
+
+
+function ProcessReporter (options) {
+  this._options = Merge({}, options);
+}
+
+
+ProcessReporter.prototype.report = function report (message, callback) {
+  const settings = Merge({
+    options: { message }
+  }, this._options);
+
+  if (typeof process.send !== 'function') {
+    return callback();
+  }
+
+  process.send(settings.options, callback);
+};

--- a/lib/plugins/signal.js
+++ b/lib/plugins/signal.js
@@ -13,7 +13,7 @@ function register (manager, options, callback) {
 function kill (options, callback) {
   const pid = options.pid || process.pid;
   let err = null;
-
+console.log('in kill')
   try {
     process.kill(pid, options.signal);
   } catch (e) {

--- a/lib/plugins/signal.js
+++ b/lib/plugins/signal.js
@@ -13,7 +13,7 @@ function register (manager, options, callback) {
 function kill (options, callback) {
   const pid = options.pid || process.pid;
   let err = null;
-console.log('in kill')
+
   try {
     process.kill(pid, options.signal);
   } catch (e) {


### PR DESCRIPTION
- TOOLBAG_PATH can be used to override toolbagrc path
- If you fork an instance with toolbag you can send commands to the forked process
