### PR TITLE
use manager's error function for nes client errors

### DIFF
--- a/lib/plugins/borland_commander.js
+++ b/lib/plugins/borland_commander.js
@@ -8,7 +8,7 @@ module.exports = { register };
 
 
 function register (manager, options, callback) {
-  const commander = new Commander(options);
+  const commander = new Commander(Object.assign(options, { manager }));
 
   manager.client.setCommander(commander);
   callback();
@@ -18,6 +18,7 @@ function register (manager, options, callback) {
 function Commander (options) {
   this._id = null;
   this._client = new Nes.Client(options.host);
+  this._client.onError = options.manager.error;
 }
 
 


### PR DESCRIPTION
Prevent nes from printing to stderr if the rest of toobag isn't using it.
